### PR TITLE
Updated Common.Logging to 3.0

### DIFF
--- a/src/Patterns.Autofac/Patterns.Autofac.csproj
+++ b/src/Patterns.Autofac/Patterns.Autofac.csproj
@@ -50,9 +50,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Castle.Core.3.2.2\lib\net40-client\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Patterns.Autofac/packages.config
+++ b/src/Patterns.Autofac/packages.config
@@ -3,5 +3,6 @@
   <package id="Autofac" version="3.3.0" targetFramework="net40" />
   <package id="AutoMapper" version="3.1.0" targetFramework="net40" />
   <package id="Castle.Core" version="3.2.2" targetFramework="net40" />
-  <package id="Common.Logging" version="2.1.2" targetFramework="net40" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net40" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net40" />
 </packages>

--- a/src/Patterns.Testing.Autofac/Patterns.Testing.Autofac.csproj
+++ b/src/Patterns.Testing.Autofac/Patterns.Testing.Autofac.csproj
@@ -45,9 +45,11 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.Extras.CommonServiceLocator.3.0.1\lib\net40\Autofac.Extras.CommonServiceLocator.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging">
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation">
       <HintPath>..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>

--- a/src/Patterns.Testing.Autofac/packages.config
+++ b/src/Patterns.Testing.Autofac/packages.config
@@ -2,7 +2,8 @@
 <packages>
   <package id="Autofac" version="3.3.0" targetFramework="net40" />
   <package id="Autofac.Extras.CommonServiceLocator" version="3.0.1" targetFramework="net40" />
-  <package id="Common.Logging" version="2.1.2" targetFramework="net40" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net40" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net40" />
   <package id="CommonServiceLocator" version="1.0" targetFramework="net45" />
   <package id="Moq" version="4.1.1311.0615" targetFramework="net40" />
 </packages>

--- a/src/Patterns/Patterns.csproj
+++ b/src/Patterns/Patterns.csproj
@@ -46,9 +46,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Castle.Core.3.2.2\lib\net40-client\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Patterns/packages.config
+++ b/src/Patterns/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="AutoMapper" version="3.1.0" targetFramework="net40" />
   <package id="Castle.Core" version="3.2.2" targetFramework="net40" />
-  <package id="Common.Logging" version="2.1.2" targetFramework="net40" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net40" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net40" />
 </packages>

--- a/src/_specs/_specs.csproj
+++ b/src/_specs/_specs.csproj
@@ -52,9 +52,11 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Castle.Core.3.2.2\lib\net40-client\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging">
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="FizzWare.NBuilder">
       <HintPath>..\packages\NBuilder.3.0.1.1\lib\FizzWare.NBuilder.dll</HintPath>

--- a/src/_specs/packages.config
+++ b/src/_specs/packages.config
@@ -4,7 +4,8 @@
   <package id="Autofac.Extras.DynamicProxy2" version="3.0.2" targetFramework="net40" />
   <package id="AutoMapper" version="3.1.0" targetFramework="net40" />
   <package id="Castle.Core" version="3.2.2" targetFramework="net40" />
-  <package id="Common.Logging" version="2.1.2" targetFramework="net40" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net40" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net40" />
   <package id="CommonServiceLocator" version="1.0" targetFramework="net40" />
   <package id="FluentAssertions" version="2.0.1" targetFramework="net40" />
   <package id="Moq" version="4.1.1311.0615" targetFramework="net40" />


### PR DESCRIPTION
I have upgraded Common.Logging to 3.0.  Older version of Common.Logging appear to be incompatible, so I am unable to use code-patterns in a project which is already using Common.Logging 3.0+.
